### PR TITLE
docs: Add permissions note to update-version workflow

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -84,6 +84,10 @@ jobs:
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       # バージョン更新のPRを自動作成
+      # 注意: このステップを動作させるには、以下のいずれかが必要です：
+      # 1. リポジトリ設定で "Allow GitHub Actions to create and approve pull requests" を有効化
+      #    Settings → Actions → General → Workflow permissions
+      # 2. または、PAT (Personal Access Token) を使用: token: ${{ secrets.PAT }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
## 概要
update-versionワークフローにGitHub Actionsの権限設定に関する詳細な注意事項を追加しました。

## 背景
ワークフロー実行時に「GitHub Actions is not permitted to create or approve pull requests」というエラーが発生したため、権限設定に関する説明を追加しました。

## 変更内容
- `.github/workflows/update-version.yml`に権限設定の注意事項を追加
- リポジトリ設定での有効化手順を明記
- Personal Access Token (PAT) の代替手段も記載

## 解決方法
このワークフローを正常に動作させるには、以下のいずれかの設定が必要です：

### 方法1: リポジトリ設定を変更（推奨）
1. GitHubリポジトリの **Settings → Actions → General** に移動
2. **Workflow permissions** セクションで以下を設定：
   - "Read and write permissions" を選択
   - "Allow GitHub Actions to create and approve pull requests" にチェック

### 方法2: Personal Access Token を使用
1. **Settings → Secrets and variables → Actions** で `PAT` シークレットを作成
2. ワークフローの `token:` を `${{ secrets.PAT }}` に変更

## 関連issue/PR
- 初回PR: #6