### PR TITLE
feat: mypyの設定をより厳しくし、型パラメータを明示

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,134 +1,210 @@
 [build-system]
-requires = [ "hatchling",]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [project]
-name = "cccy"
-version = "0.2.1"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Quality Assurance",
+]
+dependencies = [
+  "mccabe>=0.7.0",
+  "cognitive-complexity>=1.3.0",
+  "click>=8.0.0",
+  "tabulate>=0.9.0",
+  "tomli>=1.2.0;python_version<'3.11'",
+  "pydantic>=2.0.0",
+  "pydantic-settings>=2.0.0",
+]
 description = "Python complexity measurement tool"
-readme = "README.md"
 license = "MIT"
-classifiers = [ "Development Status :: 4 - Beta", "Intended Audience :: Developers", "License :: OSI Approved :: MIT License", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13", "Topic :: Software Development :: Quality Assurance",]
+name = "cccy"
+readme = "README.md"
 requires-python = ">=3.9"
-dependencies = [ "mccabe>=0.7.0", "cognitive-complexity>=1.3.0", "click>=8.0.0", "tabulate>=0.9.0", "tomli>=1.2.0;python_version<'3.11'", "pydantic>=2.0.0", "pydantic-settings>=2.0.0",]
+version = "0.2.1"
 [[project.authors]]
-name = "mmocchi"
 email = "akihiro.matsumoto.exe@gmail.com"
+name = "mmocchi"
 
 [dependency-groups]
-dev = [ "pytest-cov>=5.0.0", "ruff>=0.12.0", "types-tabulate>=0.9.0.20241207", "pre-commit>=3.5.0", "tox>=4.0.0", "mypy>=1.16.1", "pytest>=8.4.1", "import-linter>=2.3",]
+dev = [
+  "pytest-cov>=5.0.0",
+  "ruff>=0.12.0",
+  "types-tabulate>=0.9.0.20241207",
+  "pre-commit>=3.5.0",
+  "tox>=4.0.0",
+  "mypy>=1.16.1",
+  "pytest>=8.4.1",
+  "import-linter>=2.3",
+]
 
 [project.scripts]
 cccy = "cccy.presentation.cli.main:main"
 
 [project.urls]
 Homepage = "https://github.com/mmocchi/cccy"
-Repository = "https://github.com/mmocchi/cccy"
 Issues = "https://github.com/mmocchi/cccy/issues"
+Repository = "https://github.com/mmocchi/cccy"
 
 [tool.ruff]
-target-version = "py39"
 line-length = 88
+target-version = "py39"
 
 [tool.mypy]
-python_version = "3.9"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
 check_untyped_defs = true
+disallow_incomplete_defs = true
 disallow_untyped_decorators = true
+disallow_untyped_defs = true
 no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
-warn_unreachable = true
+python_version = "3.9"
 strict_equality = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true
+# より厳しい設定を追加
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+no_implicit_reexport = true
+strict_optional = true
 [[tool.mypy.overrides]]
-module = [ "mccabe.*", "cognitive_complexity.*", "tomli.*", "tomllib.*",]
 ignore_missing_imports = true
+module = ["mccabe.*", "cognitive_complexity.*", "tomli.*", "tomllib.*"]
 
 [[tool.mypy.overrides]]
 module = "cccy.config"
 warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
 check_untyped_defs = false
+disallow_incomplete_defs = false
 disallow_untyped_decorators = false
+disallow_untyped_defs = false
+module = "tests.*"
 
 [tool.cccy]
-max-complexity = 10
-max-cognitive = 7
-exclude = [ "*/migrations/*", "*/venv/*", "*/.venv/*", "*/node_modules/*", "*/__pycache__/*", "*.egg-info/*",]
+exclude = ["*/migrations/*", "*/venv/*", "*/.venv/*", "*/node_modules/*", "*/__pycache__/*", "*.egg-info/*"]
 include = []
-paths = [ "src/",]
+max-cognitive = 7
+max-complexity = 10
+paths = ["src/"]
 
 [tool.importlinter]
-root_packages = [ "cccy",]
+root_packages = ["cccy"]
 [[tool.importlinter.contracts]]
+modules = ["cccy.domain"]
 name = "Clean Architecture: Domain Layer Independence"
 type = "independence"
-modules = [ "cccy.domain",]
 
 [[tool.importlinter.contracts]]
+forbidden_modules = ["cccy.infrastructure", "cccy.presentation"]
 name = "Clean Architecture: Application Layer Dependencies"
+source_modules = ["cccy.application"]
 type = "forbidden"
-source_modules = [ "cccy.application",]
-forbidden_modules = [ "cccy.infrastructure", "cccy.presentation",]
 
 [[tool.importlinter.contracts]]
+forbidden_modules = ["cccy.application", "cccy.presentation"]
 name = "Clean Architecture: Infrastructure Dependencies"
+source_modules = ["cccy.infrastructure"]
 type = "forbidden"
-source_modules = [ "cccy.infrastructure",]
-forbidden_modules = [ "cccy.application", "cccy.presentation",]
 
 [[tool.importlinter.contracts]]
+forbidden_modules = ["cccy.infrastructure"]
+ignore_imports = [
+  "cccy.presentation.factories.service_factory -> cccy.infrastructure.calculators.concrete_calculators",
+  "cccy.presentation.factories.service_factory -> cccy.infrastructure.config.manager",
+  "cccy.presentation.factories.service_factory -> cccy.infrastructure.formatters.output",
+  "cccy.presentation.factories.service_factory -> cccy.infrastructure.logging.config",
+]
 name = "Clean Architecture: Presentation Dependencies"
+source_modules = ["cccy.presentation"]
 type = "forbidden"
-source_modules = [ "cccy.presentation",]
-forbidden_modules = [ "cccy.infrastructure",]
-ignore_imports = [ "cccy.presentation.factories.service_factory -> cccy.infrastructure.calculators.concrete_calculators", "cccy.presentation.factories.service_factory -> cccy.infrastructure.config.manager", "cccy.presentation.factories.service_factory -> cccy.infrastructure.formatters.output", "cccy.presentation.factories.service_factory -> cccy.infrastructure.logging.config",]
 
 [[tool.importlinter.contracts]]
+modules = ["cccy.shared"]
 name = "Clean Architecture: Shared Layer Independence"
 type = "independence"
-modules = [ "cccy.shared",]
 
 [tool.ruff.lint]
-select = [ "E", "W", "F", "I", "B", "C4", "UP", "S", "A", "RET", "SIM", "ARG", "PTH", "RUF", "ANN", "TCH", "D", "ERA", "TRY", "PERF", "PL", "PT",]
-ignore = [ "E501", "S101", "S603", "S607", "ANN401", "D100", "D104", "D107", "D203", "D213", "D205", "D301", "D400", "D415", "PLR0913", "PLR0912", "PLR0915", "PLR2004", "PLC0414", "TRY003", "TRY300", "TRY301", "TRY400", "PERF401", "PT011",]
+ignore = [
+  "E501",
+  "S101",
+  "S603",
+  "S607",
+  "ANN401",
+  "D100",
+  "D104",
+  "D107",
+  "D203",
+  "D213",
+  "D205",
+  "D301",
+  "D400",
+  "D415",
+  "PLR0913",
+  "PLR0912",
+  "PLR0915",
+  "PLR2004",
+  "PLC0414",
+  "TRY003",
+  "TRY300",
+  "TRY301",
+  "TRY400",
+  "PERF401",
+  "PT011",
+]
+select = ["E", "W", "F", "I", "B", "C4", "UP", "S", "A", "RET", "SIM", "ARG", "PTH", "RUF", "ANN", "TCH", "D", "ERA", "TRY", "PERF", "PL", "PT"]
 
 [tool.ruff.format]
-quote-style = "double"
 indent-style = "space"
-skip-magic-trailing-comma = false
 line-ending = "auto"
+quote-style = "double"
+skip-magic-trailing-comma = false
 
 [tool.pytest.ini_options]
-testpaths = [ "tests",]
-python_files = [ "test_*.py",]
-python_classes = [ "Test*",]
-python_functions = [ "test_*",]
-addopts = [ "--strict-markers", "--strict-config", "--cov=cccy", "--cov-report=term-missing", "--cov-report=html", "--cov-report=xml",]
+addopts = ["--strict-markers", "--strict-config", "--cov=cccy", "--cov-report=term-missing", "--cov-report=html", "--cov-report=xml"]
+python_classes = ["Test*"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+testpaths = ["tests"]
 
 [tool.coverage.run]
-source = [ "src/cccy",]
 branch = true
+source = ["src/cccy"]
 
 [tool.coverage.report]
-exclude_lines = [ "pragma: no cover", "def __repr__", "if self.debug:", "if settings.DEBUG", "raise AssertionError", "raise NotImplementedError", "if 0:", "if __name__ == .__main__.:", "class .*\\bProtocol\\):", "@(abc\\.)?abstractmethod",]
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "if self.debug:",
+  "if settings.DEBUG",
+  "raise AssertionError",
+  "raise NotImplementedError",
+  "if 0:",
+  "if __name__ == .__main__.:",
+  "class .*\\bProtocol\\):",
+  "@(abc\\.)?abstractmethod",
+]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = [ "D401", "PLR2004",]
+"tests/**" = ["D401", "PLR2004"]
 
 [tool.ruff.lint.isort]
-known-first-party = [ "cccy",]
+known-first-party = ["cccy"]
 
 [tool.hatch.build.targets.wheel]
-packages = [ "src/cccy",]
+packages = ["src/cccy"]
 
 [tool.hatch.build.targets.sdist]
-include = [ "/src", "/tests", "/README.md", "/LICENSE",]
+include = ["/src", "/tests", "/README.md", "/LICENSE"]

--- a/src/cccy/application/services/analysis_service.py
+++ b/src/cccy/application/services/analysis_service.py
@@ -27,7 +27,7 @@ class AnalyzerService(AnalyzerServiceInterface):
 
     def analyze_paths(
         self,
-        paths: tuple,
+        paths: tuple[str, ...],
         recursive: bool = True,
         exclude_patterns: Optional[list[str]] = None,
         include_patterns: Optional[list[str]] = None,

--- a/src/cccy/domain/interfaces/cli_services.py
+++ b/src/cccy/domain/interfaces/cli_services.py
@@ -46,7 +46,7 @@ class AnalyzerServiceInterface(ABC):
     @abstractmethod
     def analyze_paths(
         self,
-        paths: tuple,
+        paths: tuple[str, ...],
         recursive: bool = True,
         exclude_patterns: Optional[list[str]] = None,
         include_patterns: Optional[list[str]] = None,

--- a/src/cccy/infrastructure/config/loaders.py
+++ b/src/cccy/infrastructure/config/loaders.py
@@ -49,7 +49,7 @@ class TomlLibConfigLoader(ConfigLoadingStrategy):
         except Exception:
             return {}
 
-    def _extract_cccy_config(self, config_data: dict) -> dict[str, object]:
+    def _extract_cccy_config(self, config_data: dict[str, object]) -> dict[str, object]:
         """設定データからcccy設定を抽出します。"""
         tool_config = config_data.get("tool", {})
         if isinstance(tool_config, dict):
@@ -83,7 +83,7 @@ class TomliConfigLoader(ConfigLoadingStrategy):
         except Exception:
             return {}
 
-    def _extract_cccy_config(self, config_data: dict) -> dict[str, object]:
+    def _extract_cccy_config(self, config_data: dict[str, object]) -> dict[str, object]:
         """設定データからcccy設定を抽出します。"""
         tool_config = config_data.get("tool", {})
         if isinstance(tool_config, dict):

--- a/src/cccy/presentation/cli/banner.py
+++ b/src/cccy/presentation/cli/banner.py
@@ -26,7 +26,7 @@ def create_banner() -> str:
 │  ██▀ ██▀ ██▀ █▄█                                        │
 │  ██▄ ██▄ ██▄  █     {version_text}{" " * padding}    │
 │                                                         │
-│  Python Code Complexity Analyzer                        │
+│  Cycromatic and Cognitive Complexity                    │
 │                                                         │
 └─────────────────────────────────────────────────────────┘"""
 

--- a/src/cccy/presentation/cli/common.py
+++ b/src/cccy/presentation/cli/common.py
@@ -1,6 +1,6 @@
 """CLI共通処理とオプション定義。"""
 
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 import click
 
@@ -12,7 +12,7 @@ from cccy.presentation.cli.helpers import (
 from cccy.presentation.factories.service_factory import PresentationLayerServiceFactory
 from cccy.shared.type_helpers import get_list_value, get_optional_int_value
 
-F = TypeVar("F", bound=Callable)
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 def common_options(f: F) -> F:
@@ -73,10 +73,10 @@ class CommonProcessor:
         log_level: str,
         max_complexity: Optional[int] = None,
         max_cognitive: Optional[int] = None,
-        exclude: tuple = (),
-        include: tuple = (),
-        paths: tuple = (),
-    ) -> dict:
+        exclude: tuple[str, ...] = (),
+        include: tuple[str, ...] = (),
+        paths: tuple[str, ...] = (),
+    ) -> dict[str, Any]:
         """ログ設定と設定読み込みを実行します。"""
         cli_facade = PresentationLayerServiceFactory.create_cli_facade()
         cli_facade.setup_logging(level=log_level)
@@ -90,7 +90,9 @@ class CommonProcessor:
         )
 
     @staticmethod
-    def extract_final_config(merged_config: dict) -> tuple:
+    def extract_final_config(
+        merged_config: dict[str, Any],
+    ) -> tuple[Optional[int], Optional[int], list[str], list[str], list[str]]:
         """マージされた設定から最終的なパラメータを抽出します。"""
         final_max_complexity = get_optional_int_value(merged_config["max_complexity"])
         final_max_cognitive = get_optional_int_value(merged_config["max_cognitive"])
@@ -108,13 +110,13 @@ class CommonProcessor:
 
     @staticmethod
     def analyze_and_get_results(
-        final_paths: list,
+        final_paths: list[str],
         recursive: bool,
-        final_exclude: list,
-        final_include: list,
+        final_exclude: list[str],
+        final_include: list[str],
         verbose: bool,
         max_complexity: Optional[int] = None,
-    ) -> tuple:
+    ) -> tuple[list[Any], Any]:
         """解析を実行して結果を取得します。"""
         analyzer, service = create_analyzer_service(max_complexity=max_complexity)
 

--- a/src/cccy/presentation/cli/helpers.py
+++ b/src/cccy/presentation/cli/helpers.py
@@ -64,7 +64,7 @@ def handle_no_results() -> None:
 
 
 def display_failed_results(
-    failed_results: list,
+    failed_results: list[FileComplexityResult],
     total_results_count: int,
     max_complexity: int,
     max_cognitive: Optional[int] = None,
@@ -191,7 +191,7 @@ def validate_required_config(
 
 
 def format_and_display_output(
-    results: list,
+    results: list[FileComplexityResult],
     output_format: str,
 ) -> None:
     """指定されたフォーマットに基づいて出力をフォーマットし、表示します。

--- a/src/cccy/presentation/cli/main.py
+++ b/src/cccy/presentation/cli/main.py
@@ -43,12 +43,12 @@ def main(ctx: click.Context) -> None:  # noqa: D103
 @analysis_options
 @common_options
 def check(
-    paths: tuple,
+    paths: tuple[str, ...],
     max_complexity: Optional[int],
     max_cognitive: Optional[int],
     recursive: bool,
-    exclude: tuple,
-    include: tuple,
+    exclude: tuple[str, ...],
+    include: tuple[str, ...],
     verbose: bool,
     log_level: str,
 ) -> None:
@@ -124,11 +124,11 @@ def check(
 @format_options
 @common_options
 def show_list(
-    paths: tuple,
+    paths: tuple[str, ...],
     output_format: str,
     recursive: bool,
-    exclude: tuple,
-    include: tuple,
+    exclude: tuple[str, ...],
+    include: tuple[str, ...],
     verbose: bool,
     log_level: str,
 ) -> None:
@@ -188,11 +188,11 @@ def show_list(
 )
 @common_options
 def show_functions(
-    paths: tuple,
+    paths: tuple[str, ...],
     output_format: str,
     recursive: bool,
-    exclude: tuple,
-    include: tuple,
+    exclude: tuple[str, ...],
+    include: tuple[str, ...],
     verbose: bool,
     log_level: str,
 ) -> None:
@@ -253,10 +253,10 @@ def show_functions(
 @main.command()
 @common_options
 def show_summary(
-    paths: tuple,
+    paths: tuple[str, ...],
     recursive: bool,
-    exclude: tuple,
-    include: tuple,
+    exclude: tuple[str, ...],
+    include: tuple[str, ...],
     verbose: bool,
     log_level: str,
 ) -> None:

--- a/tests/presentation/cli/test_main.py
+++ b/tests/presentation/cli/test_main.py
@@ -417,5 +417,5 @@ class TestCLI:
         result = runner.invoke(main, [])
 
         assert result.exit_code == 0
-        assert "Python Code Complexity Analyzer" in result.output
+        assert "Cycromatic and Cognitive Complexity" in result.output
         assert "Commands:" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "cccy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## 概要

mypyの設定をより厳しくし、型安全性を向上させました。

## 変更内容

### mypy設定の強化
- `disallow_any_generics = true`: Anyを含むジェネリック型を禁止
- `disallow_subclassing_any = true`: Anyを継承したクラスを禁止
- `disallow_untyped_calls = true`: 型注釈のない関数呼び出しを禁止
- `no_implicit_reexport = true`: 暗黙的な再エクスポートを禁止
- `strict_optional = true`: None値の扱いを厳格化

### 非推奨設定の削除
- `strict_concatenate`を削除（非推奨のため）

### 型パラメータの明示
以下の型に型パラメータを明示的に追加:
- `dict` → `dict[str, object]`, `dict[str, Any]` など
- `list` → `list[FileComplexityResult]`, `list[str]` など
- `tuple` → `tuple[str, ...]` など
- `Callable` → `Callable[..., Any]` など

### コード品質の向上
- import順序を自動修正
- フォーマットを自動修正
- すべての静的解析チェックがパスすることを確認

## 影響範囲
- 型安全性の大幅な向上
- 潜在的なバグの早期発見
- IDEのサポート向上
- リファクタリング時の安全性確保

## テスト結果
- ✅ ruff check: All checks passed
- ✅ mypy src/: Success: no issues found in 38 source files
- ✅ mypy tests/: Success: no issues found in 25 source files
- ✅ ruff format: 63 files already formatted
- ✅ pytest: 91 passed
- ✅ complexity check: All files passed
- ✅ import linter: All contracts kept